### PR TITLE
Theme을 설정한다

### DIFF
--- a/packages/payment/.storybook/preview.tsx
+++ b/packages/payment/.storybook/preview.tsx
@@ -1,3 +1,8 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import { theme } from '../src/styles/theme';
+
 import type { Preview } from '@storybook/react';
 
 const preview: Preview = {
@@ -9,7 +14,14 @@ const preview: Preview = {
         date: /Date$/
       }
     }
-  }
+  },
+  decorators: [
+    Story => (
+      <ThemeProvider theme={theme}>
+        <Story />
+      </ThemeProvider>
+    )
+  ]
 };
 
 export default preview;

--- a/packages/payment/package.json
+++ b/packages/payment/package.json
@@ -27,6 +27,7 @@
     "@storybook/testing-library": "^0.1.0",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
+    "@types/styled-components": "^5.1.26",
     "@vitejs/plugin-react": "^3.1.0",
     "@vitejs/plugin-react-swc": "^3.0.0",
     "concurrently": "^8.0.1",

--- a/packages/payment/src/main.tsx
+++ b/packages/payment/src/main.tsx
@@ -1,10 +1,15 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import App from "./App";
-import "./index.css";
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-    <React.StrictMode>
-        <App />
-    </React.StrictMode>
+import { ThemeProvider } from 'styled-components';
+import { theme } from 'styles/theme';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>
 );

--- a/packages/payment/src/styles/theme.ts
+++ b/packages/payment/src/styles/theme.ts
@@ -1,17 +1,17 @@
 export const colors = {
-  PRIMARY: ' #2AC1BC',
-  PRIMARY_SOFT: '##04C09E',
+  PRIMARY: '#2AC1BC',
+  PRIMARY_SOFT: '#04C09E',
   GRAY_600: '#D2D2D2',
   GRAY_500: '#E5E5E5',
   GRAY_400: '#94DACD',
   GRAY_300: '#ECEBF1',
-  GRAY_200: '#dddddd',
-  GRAY_100: '#f6f6f6',
-  YELLOW_800: '#cbba64',
-  BLACK_500: '#111',
+  GRAY_200: '#DDDDDD',
+  GRAY_100: '#F6F6F6',
+  YELLOW_800: '#CBBA64',
+  BLACK_500: '#111111',
   BLACK_400: '#525252',
   BLACK_300: '#737373',
-  WHITE: '#fff'
+  WHITE: '#FFFFFF'
 };
 
 export const zIndex = {

--- a/packages/payment/src/styles/theme.ts
+++ b/packages/payment/src/styles/theme.ts
@@ -1,0 +1,26 @@
+export const colors = {
+  PRIMARY: ' #2AC1BC',
+  PRIMARY_SOFT: '##04C09E',
+  GRAY_600: '#D2D2D2',
+  GRAY_500: '#E5E5E5',
+  GRAY_400: '#94DACD',
+  GRAY_300: '#ECEBF1',
+  GRAY_200: '#dddddd',
+  GRAY_100: '#f6f6f6',
+  YELLOW_800: '#cbba64',
+  BLACK_500: '#111',
+  BLACK_400: '#525252',
+  BLACK_300: '#737373',
+  WHITE: '#fff'
+};
+
+export const zIndex = {
+  DRAWER: 500,
+  TOOLTIP_BOX: 400,
+  HEADER: 300
+};
+
+export const theme = {
+  colors,
+  zIndex
+} as const;

--- a/packages/payment/src/types/styled-components.d.ts
+++ b/packages/payment/src/types/styled-components.d.ts
@@ -1,0 +1,8 @@
+import 'styled-components';
+import { theme } from 'styles/theme';
+
+type ThemeConfig = typeof theme;
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends ThemeConfig {}
+}


### PR DESCRIPTION
close #1 

payments notion에 정리된 theme들을 theme provider를 통해 사용할 수 있도록 구현하였습니다 

## 구현 내용 

- theme 객체 생성
- themeProvider통해 app에 theme 주입 
- storybook에 theme 주입 
- typescript가 theme인식하기  위한 d.ts 구현 


## 추가 사항 
styled-components를 typescript가 인식하지 못하고 있어서 @types/styled-components를 설치하였습니다 
혹시 문제 있으면 제거하겠습니다! 

구현하면서 app과 storybook에서 themeProvider가 정상작동하는 것으로 확인하였지만,
각자 로컬 환경에서도 원활히 작동되는지 추가 확인 부탁드립니다 :) 