### PR TITLE
Thumbnail 컴포넌트를 구현한다.

### DIFF
--- a/packages/cart/src/components/Thumbnail/Thumbnail.stories.tsx
+++ b/packages/cart/src/components/Thumbnail/Thumbnail.stories.tsx
@@ -74,3 +74,17 @@ export const Transparent: Story = {
     </div>
   )
 };
+
+export const CursorPointer: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      <Thumbnail
+        src={SampleImage}
+        size="medium"
+        objectFit="fill"
+        isTransparent={false}
+        isCursorPointer={true}
+      />
+    </div>
+  )
+};

--- a/packages/cart/src/components/Thumbnail/Thumbnail.stories.tsx
+++ b/packages/cart/src/components/Thumbnail/Thumbnail.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Thumbnail from './Thumbnail';
+
+const SampleImage = 'https://i.pinimg.com/736x/b9/25/0f/b9250fb3ac723b0828048371beee9056.jpg';
+
+const meta: Meta<typeof Thumbnail> = {
+  title: 'Thumbnail',
+  component: Thumbnail
+};
+
+export default meta;
+type Story = StoryObj<typeof Thumbnail>;
+
+export const Large: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      <Thumbnail src={SampleImage} size="large" objectFit="fill" isTransparent={false} />
+    </div>
+  )
+};
+
+export const Medium: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      <Thumbnail src={SampleImage} size="medium" objectFit="fill" isTransparent={false} />
+    </div>
+  )
+};
+
+export const Small: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      <Thumbnail src={SampleImage} size="small" objectFit="fill" isTransparent={false} />
+    </div>
+  )
+};
+
+export const ObjectFitFill: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      <Thumbnail src={SampleImage} size="medium" objectFit="fill" isTransparent={false} />
+    </div>
+  )
+};
+
+export const ObjectFitContain: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      <Thumbnail src={SampleImage} size="medium" objectFit="contain" isTransparent={false} />
+    </div>
+  )
+};
+
+export const ObjectFitNone: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      <Thumbnail src={SampleImage} size="medium" objectFit="none" isTransparent={false} />
+    </div>
+  )
+};
+
+export const ObjectFitScaleDown: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      <Thumbnail src={SampleImage} size="medium" objectFit="scaleDown" isTransparent={false} />
+    </div>
+  )
+};
+
+export const Transparent: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      <Thumbnail src={SampleImage} size="medium" objectFit="fill" isTransparent={true} />
+    </div>
+  )
+};

--- a/packages/cart/src/components/Thumbnail/Thumbnail.stories.tsx
+++ b/packages/cart/src/components/Thumbnail/Thumbnail.stories.tsx
@@ -62,7 +62,7 @@ export const ObjectFitNone: Story = {
 export const ObjectFitScaleDown: Story = {
   render: () => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
-      <Thumbnail src={SampleImage} size="medium" objectFit="scaleDown" isTransparent={false} />
+      <Thumbnail src={SampleImage} size="medium" objectFit="scale-down" isTransparent={false} />
     </div>
   )
 };

--- a/packages/cart/src/components/Thumbnail/Thumbnail.tsx
+++ b/packages/cart/src/components/Thumbnail/Thumbnail.tsx
@@ -1,9 +1,9 @@
 import { S } from 'components/Thumbnail/styles';
-import { ThumbnailSize, ThumbnailObjectFit } from 'components/Thumbnail/types';
+import { ThumbnailSize } from 'components/Thumbnail/types';
 
 interface ThumbnailProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   size?: ThumbnailSize;
-  objectFit?: ThumbnailObjectFit;
+  objectFit?: React.CSSProperties['objectFit'];
   isTransparent?: boolean;
   isCursorPointer?: boolean;
 }

--- a/packages/cart/src/components/Thumbnail/Thumbnail.tsx
+++ b/packages/cart/src/components/Thumbnail/Thumbnail.tsx
@@ -1,0 +1,19 @@
+import { S } from 'components/Thumbnail/styles';
+import { ThumbnailSize, ThumbnailObjectFit } from 'components/Thumbnail/types';
+
+interface ThumbnailProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  size?: ThumbnailSize;
+  objectFit?: ThumbnailObjectFit;
+  isTransparent?: boolean;
+}
+
+function Thumbnail({
+  size = 'medium',
+  objectFit = 'fill',
+  isTransparent = false,
+  ...props
+}: ThumbnailProps) {
+  return <S.Thumbnail size={size} objectFit={objectFit} isTransparent={isTransparent} {...props} />;
+}
+
+export default Thumbnail;

--- a/packages/cart/src/components/Thumbnail/Thumbnail.tsx
+++ b/packages/cart/src/components/Thumbnail/Thumbnail.tsx
@@ -5,15 +5,25 @@ interface ThumbnailProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   size?: ThumbnailSize;
   objectFit?: ThumbnailObjectFit;
   isTransparent?: boolean;
+  isCursorPointer?: boolean;
 }
 
 function Thumbnail({
   size = 'medium',
   objectFit = 'fill',
   isTransparent = false,
+  isCursorPointer = false,
   ...props
 }: ThumbnailProps) {
-  return <S.Thumbnail size={size} objectFit={objectFit} isTransparent={isTransparent} {...props} />;
+  return (
+    <S.Thumbnail
+      size={size}
+      objectFit={objectFit}
+      isTransparent={isTransparent}
+      isCursorPointer={isCursorPointer}
+      {...props}
+    />
+  );
 }
 
 export default Thumbnail;

--- a/packages/cart/src/components/Thumbnail/styles.ts
+++ b/packages/cart/src/components/Thumbnail/styles.ts
@@ -1,0 +1,53 @@
+import styled, { css } from 'styled-components';
+import { ThumbnailSize, ThumbnailObjectFit } from 'components/Thumbnail/types';
+
+export const ThumbnailStyles = {
+  Size: {
+    large: css`
+      width: 478px;
+      height: 478px;
+    `,
+    medium: css`
+      width: 180px;
+      height: 180px;
+    `,
+    small: css`
+      width: 100px;
+      height: 100px;
+    `
+  },
+  ObjectFit: {
+    fill: css`
+      object-fit: fill;
+    `,
+    contain: css`
+      object-fit: contain;
+    `,
+    cover: css`
+      object-fit: cover;
+    `,
+    none: css`
+      object-fit: none;
+    `,
+    scaleDown: css`
+      object-fit: scale-dow;
+    `
+  }
+};
+
+export const S = {
+  Thumbnail: styled.img<{
+    size: ThumbnailSize;
+    objectFit: ThumbnailObjectFit;
+    isTransparent: boolean;
+  }>`
+    border: 1px solid #f5f5f5;
+    ${({ isTransparent }) =>
+      isTransparent &&
+      css`
+        opacity: 0.5;
+      `};
+    ${({ size }) => ThumbnailStyles.Size[size]};
+    ${({ objectFit }) => ThumbnailStyles.ObjectFit[objectFit]};
+  `
+};

--- a/packages/cart/src/components/Thumbnail/styles.ts
+++ b/packages/cart/src/components/Thumbnail/styles.ts
@@ -40,6 +40,7 @@ export const S = {
     size: ThumbnailSize;
     objectFit: ThumbnailObjectFit;
     isTransparent: boolean;
+    isCursorPointer: boolean;
   }>`
     border: 1px solid #f5f5f5;
     ${({ isTransparent }) =>
@@ -47,6 +48,11 @@ export const S = {
       css`
         opacity: 0.5;
       `};
+    ${({ isCursorPointer }) =>
+      isCursorPointer &&
+      css`
+        cursor: pointer;
+      `}
     ${({ size }) => ThumbnailStyles.Size[size]};
     ${({ objectFit }) => ThumbnailStyles.ObjectFit[objectFit]};
   `

--- a/packages/cart/src/components/Thumbnail/styles.ts
+++ b/packages/cart/src/components/Thumbnail/styles.ts
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { ThumbnailSize, ThumbnailObjectFit } from 'components/Thumbnail/types';
+import { ThumbnailSize } from 'components/Thumbnail/types';
 
 export const ThumbnailStyles = {
   Size: {
@@ -15,45 +15,21 @@ export const ThumbnailStyles = {
       width: 100px;
       height: 100px;
     `
-  },
-  ObjectFit: {
-    fill: css`
-      object-fit: fill;
-    `,
-    contain: css`
-      object-fit: contain;
-    `,
-    cover: css`
-      object-fit: cover;
-    `,
-    none: css`
-      object-fit: none;
-    `,
-    scaleDown: css`
-      object-fit: scale-dow;
-    `
   }
 };
 
 export const S = {
   Thumbnail: styled.img<{
     size: ThumbnailSize;
-    objectFit: ThumbnailObjectFit;
+    objectFit: React.CSSProperties['objectFit'];
     isTransparent: boolean;
     isCursorPointer: boolean;
   }>`
     border: 1px solid #f5f5f5;
-    ${({ isTransparent }) =>
-      isTransparent &&
-      css`
-        opacity: 0.5;
-      `};
-    ${({ isCursorPointer }) =>
-      isCursorPointer &&
-      css`
-        cursor: pointer;
-      `}
-    ${({ size }) => ThumbnailStyles.Size[size]};
-    ${({ objectFit }) => ThumbnailStyles.ObjectFit[objectFit]};
+
+    opacity: ${({ isTransparent }) => isTransparent && '0.5'};
+    cursor: ${({ isCursorPointer }) => isCursorPointer && 'pointer'};
+    object-fit: ${({ objectFit }) => objectFit || 'initial'}
+      ${({ size }) => ThumbnailStyles.Size[size]};
   `
 };

--- a/packages/cart/src/components/Thumbnail/types.d.ts
+++ b/packages/cart/src/components/Thumbnail/types.d.ts
@@ -1,0 +1,4 @@
+import { ThumbnailStyles } from './styles';
+
+export declare type ThumbnailSize = keyof typeof ThumbnailStyles.Size;
+export declare type ThumbnailObjectFit = keyof typeof ThumbnailStyles.ObjectFit;

--- a/packages/cart/src/components/Thumbnail/types.d.ts
+++ b/packages/cart/src/components/Thumbnail/types.d.ts
@@ -1,4 +1,3 @@
 import { ThumbnailStyles } from './styles';
 
 export declare type ThumbnailSize = keyof typeof ThumbnailStyles.Size;
-export declare type ThumbnailObjectFit = keyof typeof ThumbnailStyles.ObjectFit;


### PR DESCRIPTION
## 관련문서
- [피그마](https://www.figma.com/file/gzQzncX4OyveGZ5lKlwGC4/DRY-%EC%9E%A5%EB%B0%94%EA%B5%AC%EB%8B%88?node-id=0-1&t=PvRqo4gm8K2V3OkK-0)

## 구현사항
피그마에 맞게 아래의 props 를 추가하여 스타일을 커스텀 할 수 있도록 했습니다. 
- 이미지 사이즈
    - Large 
    - Medium (default)
    - Small
- 이미지 Object fit
   - fill (default)
   - none
   - contain
   - scaleDown  
- 이미지 Transparent 여부
    - true 
    - false (default)
    - true 일 경우 opacity 0.5가 적용됩니다.
- 이미지에 cursor pointer 여부
    - true 
    - false (default)


더 추가해야 할 것이 있거나, 리팩터링했으면 하는 부분들이 있다면 편하게 말씀해주세요!


#14 
