### PR TITLE
UnderlinedHeader 컴포넌트를 구현한다.

### DIFF
--- a/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.stories.tsx
+++ b/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.stories.tsx
@@ -6,9 +6,34 @@ const meta: Meta<typeof UnderlinedHeader> = {
   title: 'UnderlinedHeader',
   component: UnderlinedHeader,
   argTypes: {
+    width: {
+      control: 'text',
+      table: {
+        defaultValue: { summary: 'auto' }
+      }
+    },
     fontWeight: {
       options: ['normal', 'bold'],
-      control: { type: 'radio' }
+      control: { type: 'radio' },
+      table: {
+        defaultValue: { summary: 'normal' }
+      }
+    },
+    textAlign: {
+      control: 'text',
+      table: {
+        defaultValue: { summary: 'start' }
+      }
+    },
+    lineColor: {
+      table: {
+        defaultValue: { summary: theme.colors.GRAY_200 }
+      }
+    },
+    fontColor: {
+      table: {
+        defaultValue: { summary: theme.colors.BLACK_450 }
+      }
     }
   }
 };
@@ -24,6 +49,68 @@ export const Default: Story = {
 
 Default.args = {
   width: 'auto',
+  fontWeight: 'normal',
   lineColor: theme.colors.GRAY_200,
-  fontWeight: 'normal'
+  fontColor: theme.colors.BLACK_450
+};
+
+export const Width: Story = {
+  render: args => {
+    return (
+      <>
+        <UnderlinedHeader {...args} width={'auto'}>
+          width: auto
+        </UnderlinedHeader>
+        <br />
+        <UnderlinedHeader {...args} width={'fit-content'}>
+          width: fit-content
+        </UnderlinedHeader>
+        <br />
+        <UnderlinedHeader {...args} width={'25%'}>
+          width: 25%
+        </UnderlinedHeader>{' '}
+        <br />
+        <UnderlinedHeader {...args} width={'50%'}>
+          width: 50%
+        </UnderlinedHeader>
+        <br />
+        <UnderlinedHeader {...args} width={'75%'}>
+          width: 75%
+        </UnderlinedHeader>
+        <br />
+        <UnderlinedHeader {...args} width={'100%'}>
+          width: 100%
+        </UnderlinedHeader>
+      </>
+    );
+  }
+};
+
+export const TextAlign: Story = {
+  render: args => {
+    return (
+      <>
+        <UnderlinedHeader {...args} textAlign={'start'}>
+          textAlign: start
+        </UnderlinedHeader>
+        <br />
+        <UnderlinedHeader {...args} textAlign={'center'}>
+          textAlign: center
+        </UnderlinedHeader>
+        <br />
+        <UnderlinedHeader {...args} textAlign={'end'}>
+          textAlign: end
+        </UnderlinedHeader>
+        <br />
+        <UnderlinedHeader {...args} textAlign={'left'}>
+          textAlign: left
+        </UnderlinedHeader>
+        <br />
+        <UnderlinedHeader {...args} textAlign={'right'}>
+          textAlign: right
+        </UnderlinedHeader>
+        <br />
+      </>
+    );
+  }
 };

--- a/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.stories.tsx
+++ b/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import UnderlinedHeader from './UnderlinedHeader';
+import { theme } from 'styles/theme';
+
+const meta: Meta<typeof UnderlinedHeader> = {
+  title: 'UnderlinedHeader',
+  component: UnderlinedHeader,
+  argTypes: {
+    fontWeight: {
+      options: ['normal', 'bold'],
+      control: { type: 'radio' }
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof UnderlinedHeader>;
+
+export const Default: Story = {
+  render: args => {
+    return <UnderlinedHeader {...args}>UnderlinedHeader</UnderlinedHeader>;
+  }
+};
+
+Default.args = {
+  width: 'auto',
+  lineColor: theme.colors.GRAY_200,
+  fontWeight: 'normal'
+};

--- a/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.styled.tsx
+++ b/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.styled.tsx
@@ -7,9 +7,10 @@ export const Header = styled.h3<UnderlinedHeaderProps>`
   margin: 0;
   padding: 0 4px;
 
+  color: ${({ fontColor }) => fontColor || theme.colors.BLACK_450};
   font-size: 16px;
-  color: ${theme.colors.BLACK_450};
   font-weight: ${({ fontWeight }) => fontWeight || 'normal'};
+  text-align: ${({ textAlign }) => textAlign || 'start'};
 
   border: 0;
   border-bottom-width: 3px;

--- a/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.styled.tsx
+++ b/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.styled.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+import { UnderlinedHeaderProps } from './UnderlinedHeader';
+import { theme } from 'styles/theme';
+
+export const Header = styled.h3<UnderlinedHeaderProps>`
+  width: ${({ width }) => width || 'auto'};
+  margin: 0;
+  padding: 0 4px;
+
+  font-size: 16px;
+  color: ${theme.colors.BLACK_450};
+  font-weight: ${({ fontWeight }) => fontWeight || 'normal'};
+
+  border: 0;
+  border-bottom-width: 3px;
+  border-bottom-style: solid;
+  border-bottom-color: ${({ lineColor }) => lineColor || theme.colors.GRAY_200};
+`;

--- a/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.tsx
+++ b/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import * as S from './UnderlinedHeader.styled';
+
+export interface UnderlinedHeaderProps {
+  width?: React.CSSProperties['width'];
+  lineColor?: string;
+  fontWeight?: React.CSSProperties['fontWeight'];
+}
+
+const UnderlinedHeader = (props: UnderlinedHeaderProps) => {
+  return <S.Header {...props}>UnderlinedHeader</S.Header>;
+};
+
+export default UnderlinedHeader;

--- a/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.tsx
+++ b/packages/payment/src/components/UnderlinedHeader/UnderlinedHeader.tsx
@@ -3,12 +3,17 @@ import * as S from './UnderlinedHeader.styled';
 
 export interface UnderlinedHeaderProps {
   width?: React.CSSProperties['width'];
-  lineColor?: string;
   fontWeight?: React.CSSProperties['fontWeight'];
+  textAlign?: React.CSSProperties['textAlign'];
+  lineColor?: string;
+  fontColor?: string;
 }
 
-const UnderlinedHeader = (props: UnderlinedHeaderProps) => {
-  return <S.Header {...props}>UnderlinedHeader</S.Header>;
+const UnderlinedHeader = ({
+  children,
+  ...rest
+}: React.PropsWithChildren<UnderlinedHeaderProps>) => {
+  return <S.Header {...rest}>{children}</S.Header>;
 };
 
 export default UnderlinedHeader;

--- a/packages/payment/src/styles/theme.ts
+++ b/packages/payment/src/styles/theme.ts
@@ -9,6 +9,8 @@ export const colors = {
   GRAY_100: '#F6F6F6',
   YELLOW_800: '#CBBA64',
   BLACK_500: '#111111',
+  BLACK_475: '#333333',
+  BLACK_450: '#383838',
   BLACK_400: '#525252',
   BLACK_300: '#737373',
   WHITE: '#FFFFFF'


### PR DESCRIPTION
## 작업 내용
- UnderlinedHeader 컴포넌트를 만들었습니다.
- h3 태그를 이용하고 밑줄은 border-bottom 으로 스타일링 했습니다.
- fontSize는 디자인 시안대로 16px, fontWeight는 prop으로 줄 수 있도록 prop에 추가했습니다.
- 디자인따라 폰트 색상을 주려다 보니 theme colors에 중간 색상을 추가했는데요. 작업하면서 필요한 색상 계속 추가하고, 마지막에 숫자 단위 정리 다시하면 좋을 것 같습니다.
- 🧐 width에 따라 밑줄 길이 달라지도록 width도 prop으로 받을 수 있게 했는데... 이게 맞나 싶네요. 아이디어 주십쇼

스토리북 확인해보시고 수정 의견 주세요!

closed #20 